### PR TITLE
Degrade to system PATH if default git executable path does not exist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/src/AppHarbor/GitCommand.cs
+++ b/src/AppHarbor/GitCommand.cs
@@ -22,7 +22,7 @@ namespace AppHarbor
 			var processArguments = new StringBuilder();
 
 			processArguments.AppendFormat("/C ");
-			processArguments.AppendFormat("\"{0}\" ", _gitExecutable.FullName);
+			processArguments.AppendFormat("\"{0}\" ", GitExecutable);
 			processArguments.AppendFormat("{0} ", command);
 
 			var process = new Process
@@ -65,5 +65,13 @@ namespace AppHarbor
 				return new DirectoryInfo(Directory.GetCurrentDirectory());
 			}
 		}
+
+        private string GitExecutable
+        {
+            get
+            {
+                return _gitExecutable.Exists ? _gitExecutable.FullName : _gitExecutable.Name;
+            }
+        }
 	}
 }


### PR DESCRIPTION
Some git installs (like the built in GitHub Windows Git Posh client) don't install git in c:\program files, but it is accessible via the PATH in PowerShell.

P.S. my first pull request ever (a newbie), still learning here and appreciate your patience.  if I got something wrong your guidance is welcome.
