### PR TITLE
Fix DeployAppCommand to work right with source-directory parameter

### DIFF
--- a/src/AppHarbor/Commands/DeployAppCommand.cs
+++ b/src/AppHarbor/Commands/DeployAppCommand.cs
@@ -32,7 +32,15 @@ namespace AppHarbor.Commands
 			_writer = writer;
 
 			_sourceDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
-			OptionSet.Add("source-directory=", "Set source directory", x => _sourceDirectory = new DirectoryInfo(x));
+			OptionSet.Add("source-directory=", "Set source directory", x =>
+			{
+				_sourceDirectory = new DirectoryInfo(x);
+
+				if (!_sourceDirectory.Exists)
+				{
+					throw new CommandException(string.Format("The directory '{0}' does not exist or is not accessible", _sourceDirectory.FullName));
+				}
+			});
 
 			_excludedDirectories = new List<string> { ".git", ".hg" };
 			OptionSet.Add("e|excluded-directory=", "Add excluded directory name", x => _excludedDirectories.Add(x));

--- a/src/AppHarbor/CompressionExtensions.cs
+++ b/src/AppHarbor/CompressionExtensions.cs
@@ -2,12 +2,32 @@
 using System.IO;
 using System.Linq;
 using ICSharpCode.SharpZipLib.Tar;
+using System;
 
 namespace AppHarbor
 {
 	public static class CompressionExtensions
 	{
 		public static void ToTar(this DirectoryInfo sourceDirectory, Stream output, string[] excludedDirectoryNames)
+		{
+			string previousCurrDir = Environment.CurrentDirectory;
+			try
+			{
+				// Chgange the current directory to the source directory
+				// because the Tar library use it as a reference point
+				// and it will leave the specified source-directory in each
+				// tar file path otherwise.
+				Environment.CurrentDirectory = sourceDirectory.FullName;
+
+				TarDirectory(sourceDirectory, output, excludedDirectoryNames);
+			}
+			finally
+			{
+				Environment.CurrentDirectory = previousCurrDir;
+			}
+		}
+
+		private static void TarDirectory(DirectoryInfo sourceDirectory, Stream output, string[] excludedDirectoryNames)
 		{
 			var archive = TarArchive.CreateOutputTarArchive(output);
 


### PR DESCRIPTION
The Tar library use Environment.CurrentDirectory as reference path so it is needed to change it when using specified source-directory.
When specifying source-directory parameter validate the directory really exists.
