### PR TITLE
Issues calling git.exe in GitCommand.cs

### DIFF
--- a/src/AppHarbor/GitCommand.cs
+++ b/src/AppHarbor/GitCommand.cs
@@ -22,8 +22,8 @@ namespace AppHarbor
 			var processArguments = new StringBuilder();
 
 			processArguments.AppendFormat("/C ");
-			processArguments.AppendFormat("\"{0}\" ", _gitExecutable.FullName);
-			processArguments.AppendFormat("{0} ", command);
+			processArguments.AppendFormat("\"\"{0}\" ", _gitExecutable.FullName);
+			processArguments.AppendFormat("{0} \"", command);
 
 			var process = new Process
 			{

--- a/src/AppHarbor/GitCommand.cs
+++ b/src/AppHarbor/GitCommand.cs
@@ -10,12 +10,20 @@ namespace AppHarbor
 	{
 		private readonly FileInfo _gitExecutable;
 
-		public GitCommand()
-		{
-			var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-			var gitExecutablePath = Path.Combine(programFilesPath, "Git", "bin", "git.exe");
-			_gitExecutable = new FileInfo(gitExecutablePath);
-		}
+        public GitCommand()
+        {
+            var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            var gitExecutablePath = Path.Combine(programFilesPath, "Git", "bin", "git.exe");
+            _gitExecutable = new FileInfo(gitExecutablePath);
+
+            if (_gitExecutable.Exists) return;
+
+            programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            gitExecutablePath = Path.Combine(programFilesPath, "Git", "bin", "git.exe");
+            _gitExecutable = new FileInfo(gitExecutablePath);
+
+            if (!_gitExecutable.Exists) throw new FileNotFoundException();
+        }
 
 		public virtual IList<string> Execute(string command)
 		{


### PR DESCRIPTION
This pull request solves two issues in GitCommand.cs

- There seems to be a problem passing parameters to cmd.exe. It requires additional double quotes. REFERENCE: http://stackoverflow.com/questions/6376113/how-to-use-spaces-in-cmd

- Finding git.exe is much likable to be found in ProgramFiles than in ProgramFilesX86, nowadays. Added code to check both locations.